### PR TITLE
fix(card): change export mode from default to module in card component

### DIFF
--- a/src/components/Card/__tests__/Card.spec.tsx
+++ b/src/components/Card/__tests__/Card.spec.tsx
@@ -6,7 +6,7 @@ const EnzymeAdapter = require('enzyme-adapter-react-16');
 // This sets up the adapter to be used by Enzyme
 Enzyme.configure({ adapter: new EnzymeAdapter() });
 
-import Card from 'components/Card';
+import { Card } from 'components/Card';
 
 const { shallow } = Enzyme;
 

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,3 +1,3 @@
 import Card from './Card';
 
-export default Card;
+export { Card };


### PR DESCRIPTION
before:
because in file `components/index.tsx` export all from imports while file `components/Card/index.tsx` export with default so kata-kit has as whole does not have exported member named `Card` .

fix:
change `export default` to `export {}`