### PR TITLE
style(reset): add focus theme reset

### DIFF
--- a/packages/layout/src/SidebarMain.tsx
+++ b/packages/layout/src/SidebarMain.tsx
@@ -7,7 +7,7 @@ export interface SidebarMainProps {
 
 const SidebarMain: React.SFC<SidebarMainProps> = ({ logo, children }) => (
   <Root>
-    <Logo src={logo} alt="Kata.ai" />
+    {logo && <Logo src={logo} alt="Kata.ai" />}
     {children}
   </Root>
 );
@@ -15,6 +15,8 @@ const SidebarMain: React.SFC<SidebarMainProps> = ({ logo, children }) => (
 export default SidebarMain;
 
 const Root = styled('div')`
+  display: flex;
+  flex-direction: column;
   padding: 1.846153846rem /* $space-3 */ 0.615384615rem /* $space-1 */;
   width: 4.923076923rem /* $space-8 */;
   background-color: #24282d /* $gray-80 */;

--- a/packages/layout/src/SidebarMainMenu.tsx
+++ b/packages/layout/src/SidebarMainMenu.tsx
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 import classnames from 'classnames';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 
-import { variables } from '@kata-kit/theme';
-
 export interface SidebarMainMenuProps extends NavLinkProps {
   className?: string;
   icon: string;
@@ -74,11 +72,6 @@ const Root = styled(NavLink)`
 
   &:focus {
     outline: 0;
-  }
-
-  &:active {
-    border-radius: 2px;
-    box-shadow: 0 0 0 2px ${variables.colors.softKataBlue};
   }
 
   &.is-active {

--- a/packages/layout/src/SidebarMainMenu.tsx
+++ b/packages/layout/src/SidebarMainMenu.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import classnames from 'classnames';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 
+import { variables } from '@kata-kit/theme';
+
 export interface SidebarMainMenuProps extends NavLinkProps {
   className?: string;
   icon: string;
@@ -40,12 +42,14 @@ const Span = styled('span')`
 `;
 
 const Root = styled(NavLink)`
-  padding: 0.615384615rem /* $space-1 */ 0 12px;
+  margin: 0 0 16px;
+  padding: 4px 0;
   font-size: 12px;
   display: block;
   text-decoration: none;
   text-overflow: ellipsis;
   overflow: hidden;
+  transition: all 0.3s ease;
 
   & .main-menu-icon {
     width: 40px;
@@ -66,6 +70,15 @@ const Root = styled(NavLink)`
       background: #484c4f /* $gray-70 */;
       color: #949a9d /* $gray-50 */;
     }
+  }
+
+  &:focus {
+    outline: 0;
+  }
+
+  &:active {
+    border-radius: 2px;
+    box-shadow: 0 0 0 2px ${variables.colors.softKataBlue};
   }
 
   &.is-active {

--- a/packages/layout/src/SidebarSubMenu.tsx
+++ b/packages/layout/src/SidebarSubMenu.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { variables } from '@kata-kit/theme';
+
 export interface SidebarSubMenuProps extends NavLinkProps {
   className?: string;
   to: string;
@@ -30,17 +32,19 @@ export default SidebarSubMenu;
 
 const Span = styled('span')`
   font-size: 1rem;
-  color: #484c4f /* $gray-70 */;
+  color: ${variables.colors.gray70};
 `;
 
 const Root = styled(NavLink)`
   display: block;
   min-height: 35px;
   padding: 6px 8px;
-  color: #484c4f /* $gray-70 */;
+  color: ${variables.colors.gray70};
   text-decoration: none;
   margin-bottom: 0.615384615rem /* $space-1 */;
+  border: 1px solid transparent;
   border-radius: 6px /* $border-radius-medium */;
+  transition: all 0.3s ease;
 
   &:hover {
     text-decoration: none;
@@ -57,6 +61,11 @@ const Root = styled(NavLink)`
     ${Span} {
       color: #fff /* $white */;
     }
+  }
+
+  &:focus {
+    outline: 0;
+    box-shadow: 0 0 0 2px ${variables.colors.softKataBlue};
   }
 
   &.is-active {

--- a/packages/reset/src/base/_globals.scss
+++ b/packages/reset/src/base/_globals.scss
@@ -30,6 +30,11 @@ a {
   &:active {
     color: #0056b3;
   }
+
+  &:focus {
+    outline: 2px solid #0056b3;
+    outline-offset: 2px;
+  }
 }
 
 #root {

--- a/packages/theme/src/constants.ts
+++ b/packages/theme/src/constants.ts
@@ -6,7 +6,7 @@ export const defaultTheme: ThemeAttributes = {
   linkColor: variables.colors.kataBlue,
   linkColorHover: variables.colors.darkKataBlue,
   linkColorActive: variables.colors.darkKataBlue,
-  linkColorOutline: variables.colors.darkKataBlue,
+  linkColorOutline: variables.colors.lightKataBlue,
   headingColor: variables.colors.gray80,
   textColor: variables.colors.gray70,
   borderColor: 'transparent',


### PR DESCRIPTION
Adds styling reset for `a:focus` (for accessibility purposes). Also tweaked some `@kata-kit/layout` styles that gets affected directly by this PR.

EDIT: Adding demo screenshot.

![image](https://user-images.githubusercontent.com/5663877/44027791-ea7981d8-9f21-11e8-8ba6-0e4085ad61c0.png)
