### PR TITLE
fix(pagination): page buttons w/ ellipsis should be disabled

### DIFF
--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -18,7 +18,7 @@ class Pagination extends Component<PaginationProps, PaginationState> {
   generatePages = () => {
     const { total, current } = this.props;
     const maxButtons = 5;
-    const pageButtons: any[] = [];
+    const pageButtons: React.ReactText[] = [];
 
     let startPage;
     let endPage;
@@ -80,6 +80,7 @@ class Pagination extends Component<PaginationProps, PaginationState> {
               page === current && 'is-active'
             )}
             onClick={() => (isNumber(page) ? this.props.onSelect(page) : null)}
+            disabled={!isNumber(page)}
           >
             {page}
           </PaginationButton>


### PR DESCRIPTION
Ellipsis pages can't be selected anyway, so it's better to set those
buttons to `disabled`.

![image](https://user-images.githubusercontent.com/5663877/44028275-8eecc7c4-9f23-11e8-984f-876709e3058d.png)
