### PR TITLE
fix(toggle-button): wrong state

### DIFF
--- a/packages/button/src/components/ToggleButton.tsx
+++ b/packages/button/src/components/ToggleButton.tsx
@@ -15,15 +15,9 @@ class ToggleButton extends React.Component<
   ToggleButtonProps,
   ToggleButtonStates
 > {
-  static defaultProps = {
-    active: false
+  state = {
+    active: this.props.active || false
   };
-
-  static getDerivedStateFromProps(props: ToggleButtonProps) {
-    return {
-      active: props.active
-    };
-  }
 
   constructor(props: ToggleButtonProps) {
     super(props);
@@ -34,9 +28,9 @@ class ToggleButton extends React.Component<
 
   handleToggle() {
     this.setState(
-      {
-        active: !this.state.active
-      },
+      state => ({
+        active: !state.active
+      }),
       () => {
         if (this.props.onToggle) {
           this.props.onToggle(this.state.active);


### PR DESCRIPTION
Closes #35

This bug caused by the wrong use of `getDerivedStateFromProps`. Actually, we don't need that method to maintain the component state. 