### PR TITLE
fix: be able to use tslint in command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lerna": "^3.4.0",
     "listr": "^0.14.2",
     "ora": "^3.0.0",
+    "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
     "rollup": "^0.66.2",
     "rollup-plugin-auto-external": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8469,6 +8469,11 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier@^1.14.3:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
Adds prettier as a dependency because tslint needs it to run

For #49 