### PR TITLE
Escape to close modal and drawer

### DIFF
--- a/packages/drawer/src/components/Drawer.tsx
+++ b/packages/drawer/src/components/Drawer.tsx
@@ -64,6 +64,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
   }
 
   componentDidUpdate(prevProps: DrawerProps, prevState: DrawerState) {
+    // https://github.com/kata-ai/kata-kit/issues/41#issuecomment-428330899
     if (this.state.isOpen && prevState.isOpen !== this.state.isOpen) {
       const modalWrapperElement = this.drawerWrapperRef.current;
 

--- a/packages/drawer/src/components/Drawer.tsx
+++ b/packages/drawer/src/components/Drawer.tsx
@@ -39,6 +39,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
   }
 
   el: HTMLDivElement;
+  private drawerWrapperRef = React.createRef<HTMLDivElement>();
 
   constructor(props: DrawerProps) {
     super(props);
@@ -50,6 +51,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
 
     this.watchOverflow = this.watchOverflow.bind(this);
     this.onCloseDrawer = this.onCloseDrawer.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidMount() {
@@ -61,8 +63,16 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
     document.body.removeChild(this.el);
   }
 
-  componentDidUpdate(prev: DrawerProps) {
-    if (prev.isOpen !== this.props.isOpen) {
+  componentDidUpdate(prevProps: DrawerProps, prevState: DrawerState) {
+    if (this.state.isOpen && prevState.isOpen !== this.state.isOpen) {
+      const modalWrapperElement = this.drawerWrapperRef.current;
+
+      if (modalWrapperElement) {
+        modalWrapperElement.focus();
+      }
+    }
+
+    if (prevProps.isOpen !== this.props.isOpen) {
       if (this.props.isOpen) {
         document.body.classList.add('noscroll');
       } else {
@@ -77,6 +87,14 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
       this.watchOverflow(0);
     } catch (err) {
       // do nothing
+    }
+  }
+
+  handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+
+      this.onCloseDrawer();
     }
   }
 
@@ -115,11 +133,14 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
           {themeAttributes => (
             <FocusLock disabled={!this.state.isOpen}>
               <DrawerWrapper
+                innerRef={this.drawerWrapperRef}
+                tabIndex={-1}
                 theme={themeAttributes}
                 className={classnames(
                   this.state.isOpen ? 'is-open' : 'is-closed',
                   this.props.className
                 )}
+                onKeyDown={this.handleKeyDown}
               >
                 <DrawerContext.Provider value={this.getContextAPI()}>
                   {this.state.isOpen && this.props.children}

--- a/packages/modal/src/components/Modal.tsx
+++ b/packages/modal/src/components/Modal.tsx
@@ -28,6 +28,7 @@ export interface ModalState {
 
 class Modal extends React.Component<ModalProps, ModalState> {
   el: HTMLDivElement;
+  private modalWrapperRef = React.createRef<HTMLDivElement>();
 
   state = {
     show: false,
@@ -59,6 +60,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
     this.onCloseDrawer = this.onCloseDrawer.bind(this);
     this.watchOverflow = this.watchOverflow.bind(this);
     this.getContextAPI = this.getContextAPI.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidMount() {
@@ -74,6 +76,24 @@ class Modal extends React.Component<ModalProps, ModalState> {
       document.body.removeChild(this.el);
     } catch (error) {
       // do nothing
+    }
+  }
+
+  componentDidUpdate(prevProps: ModalProps, prevState: ModalState) {
+    if (this.state.show && prevState.show !== this.state.show) {
+      const modalWrapperElement = this.modalWrapperRef.current;
+
+      if (modalWrapperElement) {
+        modalWrapperElement.focus();
+      }
+    }
+  }
+
+  handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+
+      this.onCloseDrawer();
     }
   }
 
@@ -111,6 +131,8 @@ class Modal extends React.Component<ModalProps, ModalState> {
           {themeAttributes => (
             <FocusLock disabled={!this.state.show}>
               <ModalWrapper
+                innerRef={this.modalWrapperRef}
+                tabIndex={-1}
                 className={classnames(
                   this.state.show ? 'is-open' : 'is-closed',
                   this.props.className
@@ -118,6 +140,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
                 onClick={
                   !this.props.noBackdrop ? this.onCloseDrawer : undefined
                 }
+                onKeyDown={this.handleKeyDown}
                 {...themeAttributes}
               >
                 <ModalContext.Provider value={this.getContextAPI()}>

--- a/packages/modal/src/components/Modal.tsx
+++ b/packages/modal/src/components/Modal.tsx
@@ -80,6 +80,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
   }
 
   componentDidUpdate(prevProps: ModalProps, prevState: ModalState) {
+    // https://github.com/kata-ai/kata-kit/issues/41#issuecomment-428330899
     if (this.state.show && prevState.show !== this.state.show) {
       const modalWrapperElement = this.modalWrapperRef.current;
 


### PR DESCRIPTION
For https://github.com/kata-ai/kata-kit/issues/41

Live website of it: http://salty-lace.surge.sh/components/modal and http://salty-lace.surge.sh/components/drawer