### PR TITLE
New focus trap component

### DIFF
--- a/packages/common/docs/index.mdx
+++ b/packages/common/docs/index.mdx
@@ -1,8 +1,9 @@
 import { Fragment } from 'react'
 import { Example, Props } from '@kata-kit/doc-utils';
 
-import { Board, EmptyMessage } from '../src/index';
-import { boardProps, emptyMessageProps } from './props';
+import { Board, EmptyMessage, FocusTrap } from '../src/index';
+import { boardProps, emptyMessageProps, focusTrapProps } from './props';
+import { Button } from '../../button/src/index';
 
 This package contains common components used in multiple places throughout a project.
 
@@ -27,3 +28,13 @@ This component is displayed when a list item is empty.
 ### EmptyMessage Props
 
 <Props props={emptyMessageProps} />
+
+## Focus Trap
+
+Locks the focus to the content.
+
+<Example title="Focus trap" scope={{ FocusTrap, Button }} code={require('../examples/3-focus-trap.raw')} />
+
+### FocusTrap Props
+
+<Props props={focusTrapProps} />

--- a/packages/common/docs/props.ts
+++ b/packages/common/docs/props.ts
@@ -30,3 +30,11 @@ export const emptyMessageProps: PropAttributesMap = {
     defaultValue: "'Empty'"
   }
 };
+
+export const focusTrapProps: PropAttributesMap = {
+  active: {
+    description: 'Whether or not the focus lock is active',
+    type: 'boolean',
+    required: true
+  }
+};

--- a/packages/common/examples/3-focus-trap.raw.js
+++ b/packages/common/examples/3-focus-trap.raw.js
@@ -1,0 +1,30 @@
+class CommonExample3 extends React.Component {
+  constructor() {
+    this.state = {
+      active: false
+    };
+
+    this.toggleActive = this.toggleActive.bind(this);
+  }
+
+  toggleActive() {
+    this.setState(prevState => ({ active: !prevState.active }));
+  }
+
+  render() {
+    return (
+      <FocusTrap active={this.state.active}>
+        <Button onClick={this.toggleActive}>Toggle focus trap</Button>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quid adiuvas?
+          Illa tamen simplicia, vestra versuta.
+          <a href="https://www.youtube.com/watch?v=qTUnDV3MgVQ" target="_blank">
+            Quamquam tu hanc copiosiorem etiam soles dicere.
+          </a>{' '}
+          Sed ego in hoc resisto; Si longus, levis. Roges enim Aristonem, bonane
+          ei videantur haec: vacuitas doloris, divitiae, valitudo;{' '}
+        </p>
+      </FocusTrap>
+    );
+  }
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@kata-kit/assets": "^0.5.2",
     "classnames": "^2.2.6",
+    "focus-trap": "^3.0.0",
     "styled-components": "^3.4.9"
   },
   "peerDependencies": {

--- a/packages/common/src/FocusTrap.tsx
+++ b/packages/common/src/FocusTrap.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import createFocusTrap, { FocusTrap as FocusTrapInstance } from 'focus-trap';
+
+interface FocusTrapProps extends React.AllHTMLAttributes<HTMLDivElement> {
+  /** Whether or not the focus lock is active */
+  active: boolean;
+}
+
+export default class FocusTrap extends React.Component<FocusTrapProps> {
+  private rootRef = React.createRef<HTMLDivElement>();
+  private trap?: FocusTrapInstance;
+
+  componentDidMount() {
+    const rootElement = this.rootRef.current;
+
+    if (rootElement) {
+      const trap = createFocusTrap(rootElement, {
+        escapeDeactivates: false,
+        fallbackFocus: rootElement
+      });
+
+      if (this.props.active) {
+        trap.activate();
+      }
+
+      this.trap = trap;
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.trap) {
+      this.trap.deactivate();
+    }
+  }
+
+  componentDidUpdate(prevProps: FocusTrapProps) {
+    if (this.trap && prevProps.active !== this.props.active) {
+      this.props.active ? this.trap.activate() : this.trap.deactivate();
+    }
+  }
+
+  render() {
+    const { active, ...restProps } = this.props;
+
+    return <div ref={this.rootRef} tabIndex={-1} {...restProps} />;
+  }
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 import Board from './Board';
 import EmptyMessage from './EmptyMessage';
+import FocusTrap from './FocusTrap';
 
-export { Board, EmptyMessage };
+export { Board, EmptyMessage, FocusTrap };

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@kata-kit/button": "^0.5.2",
     "@kata-kit/theme": "^0.5.2",
+    "@kata-kit/common": "^0.5.2",
     "classnames": "^2.2.6",
     "react-custom-scrollbars": "^4.2.1",
-    "react-focus-lock": "^1.14.1",
     "styled-components": "^3.4.9"
   },
   "peerDependencies": {

--- a/packages/drawer/src/components/Drawer.tsx
+++ b/packages/drawer/src/components/Drawer.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { createPortal } from 'react-dom';
 import classnames from 'classnames';
-import FocusLock from 'react-focus-lock';
 
 import { Theme } from '@kata-kit/theme';
+import { FocusTrap } from '@kata-kit/common';
 
 import DrawerContext from './DrawerContext';
 import {
@@ -109,7 +109,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
 
   render() {
     const wrapper = (
-      <>
+      <FocusTrap active={this.state.isOpen}>
         {this.props.backdrop && (
           <DrawerOverlay
             className={classnames(this.state.isOpen && 'is-open')}
@@ -120,22 +120,20 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
         )}
         <Theme values={theme}>
           {themeAttributes => (
-            <FocusLock disabled={!this.state.isOpen}>
-              <DrawerWrapper
-                theme={themeAttributes}
-                className={classnames(
-                  this.state.isOpen ? 'is-open' : 'is-closed',
-                  this.props.className
-                )}
-              >
-                <DrawerContext.Provider value={this.getContextAPI()}>
-                  {this.state.isOpen && this.props.children}
-                </DrawerContext.Provider>
-              </DrawerWrapper>
-            </FocusLock>
+            <DrawerWrapper
+              theme={themeAttributes}
+              className={classnames(
+                this.state.isOpen ? 'is-open' : 'is-closed',
+                this.props.className
+              )}
+            >
+              <DrawerContext.Provider value={this.getContextAPI()}>
+                {this.state.isOpen && this.props.children}
+              </DrawerContext.Provider>
+            </DrawerWrapper>
           )}
         </Theme>
-      </>
+      </FocusTrap>
     );
     return createPortal(wrapper, this.el);
   }

--- a/packages/drawer/src/components/Drawer.tsx
+++ b/packages/drawer/src/components/Drawer.tsx
@@ -57,6 +57,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
 
     this.watchOverflow = this.watchOverflow.bind(this);
     this.onCloseDrawer = this.onCloseDrawer.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidMount() {
@@ -87,6 +88,12 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
     }
   }
 
+  handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Escape') {
+      this.onCloseDrawer();
+    }
+  }
+
   onCloseDrawer() {
     this.props.onClose();
   }
@@ -109,7 +116,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
 
   render() {
     const wrapper = (
-      <FocusTrap active={this.state.isOpen}>
+      <FocusTrap active={this.state.isOpen} onKeyDown={this.handleKeyDown}>
         {this.props.backdrop && (
           <DrawerOverlay
             className={classnames(this.state.isOpen && 'is-open')}

--- a/packages/drawer/tsconfig.json
+++ b/packages/drawer/tsconfig.json
@@ -6,7 +6,11 @@
     "rootDir": "./src",
     "outDir": "./tsc-out"
   },
-  "references": [{ "path": "../button" }, { "path": "../theme" }],
+  "references": [
+    { "path": "../button" },
+    { "path": "../theme" },
+    { "path": "../common" }
+  ],
   "include": ["./src/**/*", "../../types/**/*.d.ts"],
   "exclude": ["./lib", "./**/__stories__", "./scripts"]
 }

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "@kata-kit/button": "^0.5.2",
     "@kata-kit/theme": "^0.5.2",
+    "@kata-kit/common": "^0.5.2",
     "classnames": "^2.2.6",
     "react-custom-scrollbars": "^4.2.1",
-    "react-focus-lock": "^1.14.1",
     "styled-components": "^3.4.9"
   },
   "peerDependencies": {

--- a/packages/modal/src/components/Modal.tsx
+++ b/packages/modal/src/components/Modal.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { createPortal } from 'react-dom';
 import classnames from 'classnames';
-import FocusLock from 'react-focus-lock';
 
 import { Theme } from '@kata-kit/theme';
+import { FocusTrap } from '@kata-kit/common';
 
 import ModalDialog from './ModalDialog';
 import ModalContext from './ModalContext';
@@ -104,7 +104,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
 
   render() {
     const wrapper = (
-      <>
+      <FocusTrap active={this.state.show}>
         {!this.props.noBackdrop && (
           <ModalOverlay
             className={classnames(this.state.show ? 'is-open' : 'is-closed')}
@@ -113,25 +113,21 @@ class Modal extends React.Component<ModalProps, ModalState> {
         )}
         <Theme>
           {themeAttributes => (
-            <FocusLock disabled={!this.state.show}>
-              <ModalWrapper
-                className={classnames(
-                  this.state.show ? 'is-open' : 'is-closed',
-                  this.props.className
-                )}
-                onClick={
-                  !this.props.noBackdrop ? this.onCloseDrawer : undefined
-                }
-                {...themeAttributes}
-              >
-                <ModalContext.Provider value={this.getContextAPI()}>
-                  <ModalDialog>{this.props.children}</ModalDialog>
-                </ModalContext.Provider>
-              </ModalWrapper>
-            </FocusLock>
+            <ModalWrapper
+              className={classnames(
+                this.state.show ? 'is-open' : 'is-closed',
+                this.props.className
+              )}
+              onClick={!this.props.noBackdrop ? this.onCloseDrawer : undefined}
+              {...themeAttributes}
+            >
+              <ModalContext.Provider value={this.getContextAPI()}>
+                <ModalDialog>{this.props.children}</ModalDialog>
+              </ModalContext.Provider>
+            </ModalWrapper>
           )}
         </Theme>
-      </>
+      </FocusTrap>
     );
     return createPortal(wrapper, this.el);
   }

--- a/packages/modal/src/components/Modal.tsx
+++ b/packages/modal/src/components/Modal.tsx
@@ -63,6 +63,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
     this.onCloseDrawer = this.onCloseDrawer.bind(this);
     this.watchOverflow = this.watchOverflow.bind(this);
     this.getContextAPI = this.getContextAPI.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidMount() {
@@ -78,6 +79,12 @@ class Modal extends React.Component<ModalProps, ModalState> {
       document.body.removeChild(this.el);
     } catch (error) {
       // do nothing
+    }
+  }
+
+  handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Escape') {
+      this.onCloseDrawer();
     }
   }
 
@@ -104,7 +111,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
 
   render() {
     const wrapper = (
-      <FocusTrap active={this.state.show}>
+      <FocusTrap active={this.state.show} onKeyDown={this.handleKeyDown}>
         {!this.props.noBackdrop && (
           <ModalOverlay
             className={classnames(this.state.show ? 'is-open' : 'is-closed')}

--- a/packages/modal/tsconfig.json
+++ b/packages/modal/tsconfig.json
@@ -6,7 +6,11 @@
     "rootDir": "./src",
     "outDir": "./tsc-out"
   },
-  "references": [{ "path": "../button" }, { "path": "../theme" }],
+  "references": [
+    { "path": "../button" },
+    { "path": "../theme" },
+    { "path": "../common" }
+  ],
   "include": ["./src/**/*", "../../types/**/*.d.ts"],
   "exclude": ["./lib", "./**/__stories__", "./scripts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,10 +4727,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-lock@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.4.2.tgz#3e91141ac911352d4831215fba300d02b9faa6b4"
-  integrity sha512-jqjj49iZEVT/X8yidEMmP8oWmDKJlJy/um7OyYP42CZ0y4icCp6Fm2lTkZVcFVpt4mZ/hPtbs9ikqId7YhUelw==
+focus-trap@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-3.0.0.tgz#4d2ee044ae66bf7eb6ebc6c93bd7a1039481d7dc"
+  integrity sha512-jTFblf0tLWbleGjj2JZsAKbgtZTdL1uC48L8FcmSDl4c2vDoU4NycN1kgV5vJhuq1mxNFkw7uWZ1JAGlINWvyw==
+  dependencies:
+    tabbable "^3.1.0"
+    xtend "^4.0.1"
 
 follow-redirects@^1.0.0:
   version "1.5.8"
@@ -8761,13 +8764,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-clientside-effect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.0.0.tgz#81c4f91bd4ec0f8792ba76fe29c1d09e37fff062"
-  integrity sha512-XYOjooNlAEos60o4ha9zDb1R9h3LMJUdXJOjFH6fNUwFxXu2k+Wq4Cd0JWmurgeY0DWTzGvpNJ0cY6eHyfhL1Q==
-  dependencies:
-    shallowequal "^1.1.0"
-
 react-custom-scrollbars@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz#830fd9502927e97e8a78c2086813899b2a8b66db"
@@ -8815,15 +8811,6 @@ react-error-overlay@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
   integrity sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==
-
-react-focus-lock@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-1.14.1.tgz#58a259443a03fcca6817cb05b8239d6aa756e1ac"
-  integrity sha512-hcZ/ZxLiQyVsUFzTVB692xQy7BKgs/XksDC4rw6Z9vDE/joXADWTLZ5jHt8FNixnClOM6882b6iKXH14fnAWzQ==
-  dependencies:
-    focus-lock "^0.4.2"
-    prop-types "^15.6.2"
-    react-clientside-effect "^1.0.0"
 
 react-hot-loader@^4.3.11:
   version "4.3.11"
@@ -9846,7 +9833,7 @@ shallow-clone@^1.0.0:
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
-shallowequal@^1.0.2, shallowequal@^1.1.0:
+shallowequal@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -10445,6 +10432,11 @@ symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
+tabbable@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.1.tgz#db7512f28a9a1ed16e4275bd190131be9d5ad8e9"
+  integrity sha512-583MHIOwictf7+zbxqO/L5fBqMN6Li4SJ1XTKQA9WzHRA7c2BB+D+Ny7Y6kGqU2u+rHK59+oRzrBvMU53aZz+A==
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
For #41 

Very happy with this solution. Includes a new component using `focus-trap`. (seems like the best library, reach-ui also uses this)

Changed `Modal` and `Drawer` to use the new component. Also made them close when pressing Escape

Preview of the changes: http://hanging-face.surge.sh/components/common http://hanging-face.surge.sh/components/modal http://hanging-face.surge.sh/components/drawer